### PR TITLE
[SAHIL] removing relative import

### DIFF
--- a/fuzmatch_test.go
+++ b/fuzmatch_test.go
@@ -3,7 +3,7 @@ package fuzmatch_test
 import (
 	"testing"
 
-	"../fuzmatch"
+	"github.com/charlesvdv/fuzmatch"
 )
 
 var testLevenshtein = []struct {


### PR DESCRIPTION
Removing Relative Import, as due to this we are not able to add it in dep.
Error when we are doing dep ensure - "subpackage github.com/charlesvdv/fuzmatch does not contain usable Go code (*.LocalImportsError).. (Package is required by (root).)"